### PR TITLE
 fixed cookie clicker not working on first play

### DIFF
--- a/Games/cookie-clicker.html
+++ b/Games/cookie-clicker.html
@@ -48,11 +48,12 @@ def input(key):
         clicked_cookie()
 
 def set_localStorage():
-    score = localStorage.setItem('cc_score',0)
-    multiplier = localStorage.setItem('cc_multiplier',1)
-    multiplierCost = localStorage.setItem('cc_multiplierCost',100)
-    passive = localStorage.setItem('cc_passive',1)
-    passiveCost = localStorage.setItem('cc_passiveCost',100)
+    localStorage.setItem('cc_score',0)
+    localStorage.setItem('cc_multiplier',1)
+    localStorage.setItem('cc_multiplierCost',100)
+    localStorage.setItem('cc_passive',1)
+    localStorage.setItem('cc_passiveCost',100)
+    get_localStorage()
 
 def get_localStorage():
     score = localStorage.getItem('cc_score')


### PR DESCRIPTION
This pr fixes an issue which causes the game to fail to run if it is the players first time playing before the game save update. This is solved by making the variables set after setting the localStorage variables which originally just saved whether the variables actually saved or not instead of the value saved